### PR TITLE
[GAG-10610] Amplify Rails upgrade - additional tasks 2

### DIFF
--- a/lib/turbolinks/version.rb
+++ b/lib/turbolinks/version.rb
@@ -1,3 +1,3 @@
 module Turbolinks
-  VERSION = '2.5.4'
+  VERSION = '2.5.5.rc1'
 end

--- a/lib/turbolinks/x_domain_blocker.rb
+++ b/lib/turbolinks/x_domain_blocker.rb
@@ -5,8 +5,8 @@ module Turbolinks
   module XDomainBlocker
     private
       def same_origin?(a, b)
-        a = URI.parse URI.escape(a)
-        b = URI.parse URI.escape(b)
+        a = URI.parse CGI.escape(a)
+        b = URI.parse CGI.escape(b)
         [a.scheme, a.host, a.port] == [b.scheme, b.host, b.port]
       end
 


### PR DESCRIPTION
References: [GAG-10610], [GAG-9488]

This PR replaces `URI.escape` with `CGI.escape` to ensure compatibility with Ruby 3

[GAG-10610]: https://gaggleamp.atlassian.net/browse/GAG-10610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[GAG-9488]: https://gaggleamp.atlassian.net/browse/GAG-9488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ